### PR TITLE
User preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ nvm alias default 4.2.1
 
 * Install bower (`npm install -g bower`) for getting front-end components easily
 * Install nodemon (`npm install -g nodemon`) for reloading node apps automatically on changes
-* Install the Less CSS compiler (`npm install -g less`) for compiling `.less` to `.css` manually, if needed sometimes.
+* Install the Less CSS compiler (`npm install -g lessc`) for compiling `.less` to `.css` manually, if needed sometimes.
 
 ## Repo
 

--- a/app.js
+++ b/app.js
@@ -155,7 +155,6 @@ passport.use('local-signup', new LocalStrategy(
   }
 ));
 
-
 // main routes
 app.use('/', require('./routes/index'));
 app.use('/group', require('./routes/group'));

--- a/app.js
+++ b/app.js
@@ -159,6 +159,7 @@ passport.use('local-signup', new LocalStrategy(
 app.use('/', require('./routes/index'));
 app.use('/group', require('./routes/group'));
 app.use('/api/1/groups', require('./routes/api/1/groups'));
+app.use('/api/1/preferences', require('./routes/api/1/preferences'));
 
 // if none of routes above match
 // catch 404 and forward to error handler

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,6 @@
     "lodash": "~3.10.1",
     "jquery": "~2.1.4",
     "bootstrap": "~3.3.5",
-    "webcomponentsjs": "~0.7.15",
     "jquery-methodOverride": "*"
   }
 }

--- a/database.js
+++ b/database.js
@@ -141,7 +141,7 @@ Database.getUserById = function(userId, callback) {
  * @param {string} userId
  */
 Database.setPreferencesForUserId = function(preferences, userId) {
-  this.userdb.update({id: userId}, {'$set': {preferences: preferences}, function(err, item) {
+  this.userdb.update({id: userId}, {'$set': {preferences: preferences}}, function(err, item) {
     if (err) {
       throw err;
     }

--- a/database.js
+++ b/database.js
@@ -6,7 +6,7 @@ const mongo = require('mongoskin');
 
 /**
  * A Database Adaptor
- * Need to decide if we should use a
+ * TODO: Need to decide if we should use a
  * Singleton Pattern for the database as well.
  */
 var Database = {};
@@ -17,6 +17,7 @@ var Database = {};
 Database.init = function() {
   this.database = mongo.db('mongodb://localhost:27017/fuse');
   this.groupsdb = this.database.collection('groups');
+  this.userdb = this.database.collection('user');
   return this;
 };
 
@@ -27,7 +28,7 @@ Database.init = function() {
  */
 Database.getGroupByName = function(name, callback) {
   return this.groupsdb.findOne({name: name}, callback);
-}
+};
 
 /**
  * Get group by id and perform the callback on it
@@ -36,7 +37,7 @@ Database.getGroupByName = function(name, callback) {
  */
 Database.getGroupByID = function(id, callback) {
   return this.groupsdb.findOne({id: id}, callback);
-}
+};
 
 /**
  * Add the given group to the databas and perform the callback on it
@@ -47,7 +48,7 @@ Database.addGroup = function(group, callback) {
     if(result) { callback(err, result.ops[0]); }
     else { callback(err, result); }
   });
-}
+};
 
 /**
  * Run the given function on the groups
@@ -57,7 +58,7 @@ Database.addGroup = function(group, callback) {
  */
 Database.getAllGroups = function(callback) {
   return this.groupsdb.find().toArray(callback);
-}
+};
 
 /**
  * Remove group from database
@@ -66,7 +67,7 @@ Database.getAllGroups = function(callback) {
  */
 Database.deleteGroup = function(group, callback) {
   return this.groupsdb.remove({id: group.id}, callback);
-}
+};
 
 /**
  * Remove group from database by id
@@ -75,7 +76,7 @@ Database.deleteGroup = function(group, callback) {
  */
 Database.deleteGroupById = function(groupId, callback) {
   return this.groupsdb.remove({id: groupId}, callback);
-}
+};
 
 /**
  * Remove group from database by name
@@ -84,7 +85,7 @@ Database.deleteGroupById = function(groupId, callback) {
  */
 Database.deleteGroupById = function(groupName, callback) {
   this.groupsdb.remove({name: groupName}, callback);
-}
+};
 
 /**
  * Adds the message to the given group
@@ -97,7 +98,7 @@ Database.addMessageToGroup = function(message, group) {
       throw err;
     }
   });
-}
+};
 
 /**
  * Adds the message to the given group by its id
@@ -110,7 +111,7 @@ Database.addMessageToGroupById = function(message, groupId) {
       throw err;
     }
   });
-}
+};
 
 /**
  * Adds the message to the given group by its name
@@ -123,6 +124,28 @@ Database.addMessageToGroupByName = function(message, groupName) {
       throw err;
     }
   });
-}
+};
+
+/**
+ * Get the user by user id. The callback receives the result of the operation.
+ * @param  {string}   userId
+ * @param  {Function} callback
+ */
+Database.getUserById = function(userId, callback) {
+  this.userdb.findOne({id: userId}, callback);
+};
+
+/**
+ * Set the preferences for the user id
+ * @param {Preferences} preferences
+ * @param {string} userId
+ */
+Database.setPreferencesForUserId = function(preferences, userId) {
+  this.userdb.update({id: userId}, {'$set': {preferences: preferences}, function(err, item) {
+    if (err) {
+      throw err;
+    }
+  });
+};
 
 module.exports = Database;

--- a/helpers/passport-functions.js
+++ b/helpers/passport-functions.js
@@ -3,12 +3,11 @@ const defines = require(app_root_path + '/defines');
 const User = require(app_root_path + '/models/user.js');
 const express = require('express');
 const router = express.Router();
+const bcrypt = require('bcryptjs');
+const Q = require('q');
 const mongo = require('mongoskin');
 const db = mongo.db('mongodb://localhost:27017/fuse');
 const userdb = db.collection('user');
-
-var bcrypt = require('bcryptjs'),
-    Q = require('q');
 
 // used in local-signup strategy
 exports.localReg = function (username, password) {
@@ -20,7 +19,7 @@ exports.localReg = function (username, password) {
     };
   
     // check if username is already assigned in our database
-    userdb.findOne({ name: username}, function(err, item){
+    userdb.findOne({ name: username}, function(err, item) {
         if(err) {
             throw err;
         }
@@ -81,5 +80,10 @@ exports.localAuth=function(username, password){
     });
 
     return deferred.promise;
+};
+
+// Extract the current user from a req object
+exports.currentUser = function(req) {
+    return req.session.passport && req.session.passport.user;
 };
 

--- a/models/preferences.js
+++ b/models/preferences.js
@@ -1,0 +1,49 @@
+const app_root_path = require('app-root-path').path;
+
+/**
+ * The Preferences class
+ */
+var Preferences = {};
+
+/**
+ * Initializes preferences to "zero" values
+ * @return {Preferences}
+ */
+Preferences.init = function() {
+    this.hotwords = new Set();
+    this.notifications = false;
+    return this;
+};
+
+/**
+ * Add a single hotword or array of hotwords
+ * @param {string|Array<string>} h
+ */
+Preferences.addHotword = function(h) {
+    if (!Array.isArray(h)) {
+        h = [h];
+    }
+
+    Set.prototype.add.apply(this.hotwords, h);
+};
+
+/**
+ * Remove a single hotword or array of hotwords
+ * @param {string|Array<string>} h
+ */
+Preferences.removeHotword = function(h) {
+    if (!Array.isArray(h)) {
+        h = [h];
+    }
+
+    Set.prototype.delete.apply(this.hotwords, h);
+};
+
+Preferences.toJSON = function() {
+    return {
+        notifications: this.notifications,
+        hotwords: Array.from(this.hotwords)
+    };
+};
+
+module.exports = Preferences;

--- a/models/user.js
+++ b/models/user.js
@@ -1,4 +1,5 @@
 const shortid = require('shortid');
+const Preferences = require('./preferences.js');
 
 /**
  * The User class
@@ -17,7 +18,8 @@ User.init = function(username, password) {
     // TODO: add photo url?
     this.name = username;
     this.id = shortid.generate();
-    this.password =password; 
+    this.password = password; 
+    this.preferences = Object.create(Preferences).init();
     return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "app-root-path": "^1.0.0",
+    "bcryptjs": "^0.7.12",
     "body-parser": "~1.13.2",
-    "bcryptjs" : "^0.7.12",
     "cookie-parser": "~1.3.5",
     "cors": "^2.7.1",
     "debug": "~2.2.0",
@@ -27,6 +27,7 @@
     "passport": "^0.2.1",
     "passport-facebook": "^1.0.3",
     "passport-google": "^0.3.0",
+    "passport-google-oauth": "^0.2.0",
     "passport-local": "^1.0.0",
     "passport-twitter": "^1.0.2",
     "q": "^1.0.1",

--- a/public/javascripts/group.js
+++ b/public/javascripts/group.js
@@ -165,12 +165,11 @@ createGroupButton.addEventListener('click', function(e) {
     });
 });
 
-
 // handle newly created group events from the server
 defines.socket.on(defines['socket-group-created'], function(data) {
   Geo.groupWithinDistance(data, function(isWithinDistance) {
     if(isWithinDistance) {
-      console.log("Within distance");
+      console.log("Within distance", data);
       G.addToSidebar(data);
     }
   });
@@ -179,11 +178,5 @@ defines.socket.on(defines['socket-group-created'], function(data) {
 // handle group removed events from the server
 defines.socket.on(defines['socket-group-removed'], function(data) {
     // TODO
-    console.log(data);
+    console.log('TODO: group removed', data);
 });
-
-G.start = function() {
-    // G.refreshGroupListNames();
-};
-
-// G.start();

--- a/public/javascripts/helpers/toolbelt.js
+++ b/public/javascripts/helpers/toolbelt.js
@@ -48,7 +48,7 @@
         obj = _.clone(obj);
 
         Object.keys(normal).forEach(function(key) {
-            if (defines.DEBUG && !Object.hasOwnProperty(key)) {
+            if (defines.DEBUG && !obj.hasOwnProperty(key)) {
                 console.warn(`expected key: ${key} missing in object:`, obj)
             }
 

--- a/public/javascripts/preferences.js
+++ b/public/javascripts/preferences.js
@@ -4,3 +4,76 @@
 // - keep user preferences in sync with the server
 
 // TODO
+
+var Pref = {};
+
+defines['preferences-url-base'] = `/api/${defines.API_VERSION}/preferences`;
+
+Pref.NOTIFICATION_NODE_SELECTOR = ".modal#fc-preferences .fc-preferences-notifications";
+Pref.HOTWORDS_NODE_SELECTOR = ".modal#fc-preferences .fc-preferences-hotwords";
+
+/**
+ * @return {boolean}
+ */
+Pref.isNotificationsEnabled = function() {
+    return false;
+};
+
+/**
+ * Returns a set of the user's hotwords
+ * @return {Set<string>}
+ */
+Pref.hotwords = function() {
+    return new Set();
+};
+
+Pref.updateLocal = function(preferences) {
+    var notificationCheckBox = document.querySelector(Pref.NOTIFICATION_NODE_SELECTOR);
+    var hotwordsBox = document.querySelector(Pref.HOTWORDS_NODE_SELECTOR);
+    notificationCheckBox.checked = preferences.notifications;
+    hotwordsBox.value = preferences.hotwords.join(', ');
+};
+
+Pref.fetchFromServer = function(fn) {
+    $.get(defines['preferences-url-base'], fn);
+};
+
+Pref.saveToServer = function(preferences, opt_fn) {
+    var defaultPreferencesParams = { notifications: false, hotwords: [] };
+    preferences = toolbelt.normalize(preferences, defaultPreferencesParams);
+    $.post(defines['preferences-url-base'], {preferences: preferences}, opt_fn || function(res) {
+        console.log('successfully updated preferences', res);
+    });
+};
+
+Pref.handleCancel = function() {
+    Pref.fetchFromServer(function(res) {
+        Pref.updateLocal(res);
+    });
+};
+
+Pref.handleSave = function() {
+    var notificationCheckBox = document.querySelector(Pref.NOTIFICATION_NODE_SELECTOR);
+    var hotwordsBox = document.querySelector(Pref.HOTWORDS_NODE_SELECTOR);
+    var preferences = {
+        notifications: notificationCheckBox.checked,
+        hotwords: hotwordsBox.value.split(',').map(s => s.trim())
+    };
+
+    Pref.saveToServer(preferences, function() {
+        Pref.updateLocal(preferences);
+    });
+};
+
+window.addEventListener('load', function() {
+    var saveButton = document.querySelector('.modal#fc-preferences .fc-preferences-save');
+    var cancelButton = document.querySelector('.modal#fc-preferences .fc-preferences-cancel');
+
+    saveButton.addEventListener('click', function() {
+        Pref.handleSave();
+    });
+
+    cancelButton.addEventListener('click', function() {
+        Pref.handleCancel();
+    });
+});

--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -53,6 +53,14 @@ a, a:visited, a:hover, a:focus, a:active {
 }
 
 // ======================================================
+// Modals
+
+#fc-preferences .modal-content,
+#fc-create-group .modal-content {
+    padding: 0 1.5rem;
+}
+
+// ======================================================
 // Group list
 
 .fc-group-list {
@@ -82,9 +90,8 @@ a.fc-group-list-item-link {
     width: 100% - @fc-left-sidebar-width;
 }
 
-
-
 // override yeti
 nav.navbar.navbar-inverse {
     margin: 0;
 }
+

--- a/routes/api/1/preferences.js
+++ b/routes/api/1/preferences.js
@@ -28,17 +28,17 @@ router.get('/', function(req, res) {
 /**
  * Set the preferences for the logged-in user
  *
- * Request body should have a `preferences` paramater that is a JSON-ified string of the preferences
+ * Request body should have a `preferences` paramater that is a JSON-ified string of the preferences.
  * preferences: {!string}
  */
 router.post('/', function(req, res) {
-  var currentUser = passportHelpers(req);
+  var currentUser = passportHelpers.currentUser(req);
   if (currentUser == null) { // not signed-in
     throw new Error('not signed in');
   }
 
   var userId = currentUser.id;
-  var preferences = JSON.parse(req.body.preferences);
+  var preferences = req.body.preferences;
   database.setPreferencesForUserId(preferences, userId);
 
   res.json({ok: true});

--- a/routes/api/1/preferences.js
+++ b/routes/api/1/preferences.js
@@ -1,0 +1,49 @@
+const app_root_path = require('app-root-path').path;
+const defines = require(app_root_path + '/defines');
+const Database = require(app_root_path + '/database');
+const express = require('express');
+const router = express.Router();
+const passportHelpers = require(app_root_path + '/helpers/passport-functions.js');
+
+const database = Object.create(Database).init();
+
+/**
+ * Get preferences for logged-in user
+ */
+router.get('/', function(req, res) {
+  var currentUser = passportHelpers(req);
+  if (currentUser == null) { // not signed-in
+    throw new Error('not signed in');
+  }
+
+  database.getUserById(currentUser.id, function(err, user) {
+    if (err) {
+      throw err;
+    }
+
+    res.json(user);
+  });
+});
+
+/**
+ * Set the preferences for the logged-in user
+ *
+ * Request body should have a `preferences` paramater that is a JSON-ified string of the preferences
+ * preferences: {!string}
+ */
+router.post('/', function(req, res) {
+  var currentUser = passportHelpers(req);
+  if (currentUser == null) { // not signed-in
+    throw new Error('not signed in');
+  }
+
+  var userId = currentUser.id;
+  var preferences = JSON.parse(req.body.preferences);
+  database.setPreferencesForUserId(preferences, userId);
+
+  res.json({ok: true});
+});
+
+
+module.exports = router;
+

--- a/routes/group.js
+++ b/routes/group.js
@@ -6,37 +6,46 @@ const router = express.Router();
 const Database = require(app_root_path + '/database');
 const passportHelpers = require(app_root_path + '/helpers/passport-functions.js')
 
-database = Object.create(Database).init();
+const database = Object.create(Database).init();
+
 // TODO: cleanup
 // get the group id, given the name
 // for that item set the `selected` key
 // then send all items so they can be used for the `selected` attribute
 router.get('/:name', function(req, res) {
-  var groupName = req.params.name;
-  database.getGroupByName(groupName, function(err, group) {
-    if(err) { throw err; }
-    // If item does not exist, throw a 404
-    // TODO: Make this send the error page
-    if(!group) {
-      res.status(404).send("Not found");
-      return false;
-    }
-    var id = group.id;
-    database.getAllGroups(function(err, groups) {
-      if(err) { throw err; }
-      var selectedGroup = null;
-      groups.some(function(item) {
-        if (item.id === id) {
-          selectedGroup = item;
-          item.selected = true;
-          return true;
+    var groupName = req.params.name;
+    database.getGroupByName(groupName, function(err, group) {
+        if(err) { throw err; }
+        
+        // If item does not exist, throw a 404
+        // TODO: Make this send the error page
+        if(!group) {
+            res.status(404).send("Not found");
+            return false;
         }
-      });
-      
-      var username = passportHelpers.name;
-      res.render('index', { title: 'Fuse Chat', groups: groups, selectedGroup: selectedGroup, username: username });
+
+        var id = group.id;
+        database.getAllGroups(function(err, groups) {
+            if(err) { throw err; }
+            
+            var selectedGroup = null;
+            groups.some(function(item) {
+                if (item.id === id) {
+                    selectedGroup = item;
+                    item.selected = true;
+                    return true;
+                }
+            });
+
+            var username;      
+            var currentUser = passportHelpers.currentUser(req);
+            if (currentUser != null) {
+                username = currentUser.name;
+            }
+
+            res.render('index', { title: 'Fuse Chat', groups: groups, selectedGroup: selectedGroup, username: username });
+        });
     });
-  });
 });
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -15,6 +15,7 @@ const LocalStrategy = require('passport-local');
 const TwitterStrategy = require('passport-twitter');
 const GoogleStrategy = require('passport-google');
 const FacebookStrategy = require('passport-facebook');
+const passportHelpers = require(app_root_path + '/helpers/passport-functions.js');
 
 //===============ROUTES=================
 // displays our sign-in/sign-up page
@@ -81,10 +82,9 @@ router.get('/postSignIn',function(req, res, next) {
         }
         
         var name = req.query.id;
-        //the username of logfed in user
         
         // set the first one to be the selected one
-        //items[0].selected = true;
+        // items[0].selected = true;
         res.render('index', { title: 'Fuse Chat', groups: items, selectedGroup: items[0], username: name});
     });
 }); 
@@ -92,8 +92,10 @@ router.get('/postSignIn',function(req, res, next) {
 // GET home page.
 // - If the user is signed in, show all the groups
 // - Redirect to sign in the user
-router.get('/', function(req, res, next) {    
-    if (req.session.passport && req.session.passport.user) { // signed-in
+router.get('/', function(req, res, next) {
+    var user = passportHelpers.currentUser(req);
+
+    if (user != null) { // signed-in
         console.log('main route: signed in', req.session.passport.user);
 
         database.getAllGroups(function(err, items) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,10 +1,10 @@
-var express = require('express');
-var router = express.Router();
+const express = require('express');
+const router = express.Router();
 const app_root_path = require('app-root-path').path;
 const Database = require(app_root_path + '/database');
 var util = require('util');
 
-var database = Object.create(Database).init();
+const database = Object.create(Database).init();
 const mongo = require('mongoskin');
 const db = mongo.db('mongodb://localhost:27017/fuse');
 const groupsdb = db.collection('groups');

--- a/routes/index.js
+++ b/routes/index.js
@@ -25,18 +25,16 @@ router.get('/signin', function(req, res){
 
 router.get('/auth/google', passport.authenticate('google', { scope : ['profile', 'email'] }));
 
-    // the callback after google has authenticated the user
-    router.get('/auth/google/callback',
-            passport.authenticate('google', {
-                    successRedirect : '/',
-                    failureRedirect : '/login'
-            }));
-
+// the callback after google has authenticated the user
+router.get('/auth/google/callback', passport.authenticate('google', {
+    successRedirect : '/',
+    failureRedirect : '/login'
+}));
 
 //sends the request through our local signup strategy, and if successful takes user to homepage, otherwise returns then to signin page
 router.post('/local-reg', passport.authenticate('local-signup', {
-  successRedirect: '/',
-  failureRedirect: '/signin'
+    successRedirect: '/',
+    failureRedirect: '/signin'
 }));
 
 // sends the request through our local login/signin strategy, and if successful takes user to homepage, otherwise returns then to signin page
@@ -47,33 +45,17 @@ router.post('/login', passport.authenticate('local-signin', {
 
 
 //logs user out of site, deleting them from the session, and returns to homepage
-router.get('/logout', function (req, res){
+router.get('/logout', function (req, res) {
 	req.logOut();
 	req.session.destroy(function (err) {
-    res.redirect('/'); //Inside a callback… bulletproof!
-  })});
+        res.redirect('/'); //Inside a callback… bulletproof!
+    });
+});
 
-// // logs user out of site, deleting them from the session, and returns to homepage
-// router.get('/logout', function(req, res){
-//     console.log("passport: route: logout: logging out ", req.user);
-//     var username = req.user.name; // need to capture before calling logout
-//     req.logout();
-//     req.session.notice = "You have successfully been logged out " + username + "!";
-//     res.redirect('/');
-// });
-// router.get('/logout', function(req, res){
-//   // var name = req.user.username;
-//   // console.log("LOGGIN OUT " + req.user.username)
-//   req.logout();
-//   res.redirect('/');
-//   //req.session.notice = "You have successfully been logged out " + name + "!";
-// });
-
-// TODO: incomplete
-// use local sign-in/sign-up instead
 router.get('/auth/facebook', function(req,res){
     res.render('facebookSignin');
 });
+
 // called from facebooksignin.hbs. uses query string parameter passing
 router.get('/postSignIn',function(req, res, next) {
     groupsdb.find().toArray(function(err, items) {

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -48,7 +48,7 @@
                 <li><a href="#">
                     <i class="fa fa-bell"></i>
                 </a></li>
-                <li><a href="#">
+                <li><a href="" data-toggle="modal" data-target=".modal#fc-preferences">
                     <i class="fa fa-cog"></i>
                     Preferences
                 </a></li>
@@ -100,7 +100,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                <h4 class="modal-title">Modal title</h4>
+                <h4 class="modal-title">Create Group</h4>
             </div>
             <div class="form-group">
                 <input class="form-control fc-group-name" type="text" placeholder="Group name">
@@ -108,6 +108,29 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-default fc-cancel" data-dismiss="modal">Close</button>
                 <button type="button" class="btn btn-primary fc-create" data-dismiss="modal">Create group</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{!-- preferences modal --}}
+<div class="modal" id="fc-preferences">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                <h4 class="modal-title">Preferences</h4>
+            </div>
+            <div class="form-group">
+                <label>Hotwords</label>
+                <textarea class="form-control fc-preferences-hotwords" type="text" placeholder="pizza, hitchhiking, tea, liverpool fc"></textarea>
+                <div class="checkbox">
+                  <label><input type="checkbox" value="" class="fc-preferences-notifications">Show notifications</label>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default fc-preferences-cancel" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary fc-preferences-save" data-dismiss="modal">Save</button>
             </div>
         </div>
     </div>

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -38,6 +38,7 @@
         <script type="text/javascript" src="/javascripts/geolocation.js"></script>
         <script type="text/javascript" src="/javascripts/positionfunctions.js"></script>
         <script type="text/javascript" src="/javascripts/notifications.js"></script>
+        <script type="text/javascript" src="/javascripts/preferences.js"></script>
     </body>
 </html>
 


### PR DESCRIPTION
#### Overview

Preferences belong to a User instance. The initialization for a user creates a "zeroed" out preferences for the user (`false` for notifications shown, and empty set for list of hotwords). When preferences are updated, the entire preferences object in the database is updated.

Currently, the preferences are:
- display notifications (boolean)
- hotwords to watch for (list)

GET `/` on the preferences base API route gets the preferences of the currently logged in user.
POST `/` on the preferences base API route updates the preferences of the currently logged in user. 
If there is no logged in user on the session, a `500` status code is returned.
#### Description of major changes
- Add modal for preferences on client side
- Communication between frontend and backend for preferences
- Database functions and routes for user preferences
